### PR TITLE
Handled string format specifiers

### DIFF
--- a/handle_string.c
+++ b/handle_string.c
@@ -1,0 +1,143 @@
+#include "main.h"
+
+/**
+ * handle_string - appends a string to the string buffer
+ * @spec: format specifier information (unused)
+ * @args: the arguments list
+ * @buffer: the string buffer to store the result
+ *
+ * Return: the number of characters appended to the string @buffer
+ */
+int handle_string(__attribute__((unused)) const format_specifier * spec,
+		va_list args, string_buffer *buffer)
+{
+	char *str = va_arg(args, char *);
+	size_t initial_length = buffer->length;
+	int characters_added;
+
+	if (str)
+	{
+		append_string(buffer, str);
+	}
+	else
+	{
+		append_string(buffer, "(null)");
+	}
+
+	characters_added = buffer->length - initial_length;
+	return (characters_added);
+}
+
+/**
+ * handle_string_reversal - appends a reversed string to the string buffer
+ * @spec: format specifier information (unused)
+ * @args: the arguments list
+ * @buffer: the string buffer to store the result
+ *
+ * Return: the number of characters appended to the string @buffer
+ */
+int handle_string_reversal(
+			__attribute__((unused)) const format_specifier * spec, va_list args,
+			string_buffer *buffer)
+{
+	char *str, *dup_str;
+	int characters_added;
+	size_t str_len, initial_length;
+
+	str = va_arg(args, char *);
+	initial_length = buffer->length;
+
+	if (str)
+	{
+		dup_str = _strdup(str);
+		if (dup_str == NULL)
+			return (0); /* memory allocation failed, nothing is written */
+
+		str_len = _strlen(str);
+		_reverse_str(dup_str, str_len);
+		append_string(buffer, dup_str);
+		safe_free(dup_str);
+	}
+	else
+	{
+		append_string(buffer, "(null)");
+	}
+
+	characters_added = buffer->length - initial_length;
+	return (characters_added);
+}
+
+/**
+ * handle_rot13 - appends a ROT13 string to the string buffer
+ * @spec: format specifier information (unused)
+ * @args: the arguments list
+ * @buffer: the string buffer to store the result
+ *
+ * Return: the number of characters appended to the string @buffer
+ */
+int handle_rot13(__attribute__((unused)) const format_specifier * spec,
+		va_list args, string_buffer *buffer)
+{
+	char *str, *dup_str;
+	int characters_added;
+	size_t initial_length;
+
+	str = va_arg(args, char *);
+	initial_length = buffer->length;
+
+	if (str)
+	{
+		dup_str = _strdup(str);
+		if (dup_str == NULL)
+			return (0); /* memory allocation failed, nothing is written */
+
+		rot13(dup_str);
+		append_string(buffer, dup_str);
+		safe_free(dup_str);
+	}
+	else
+	{
+		append_string(buffer, "(null)");
+	}
+
+	characters_added = buffer->length - initial_length;
+	return (characters_added);
+}
+
+/**
+ * handle_custom_string - appends a custom string to the string buffer
+ * @spec: format specifier information (unused)
+ * @args: the arguments list
+ * @buffer: the string buffer to store the result
+ *
+ * Return: the number of characters appended to the string @buffer
+ */
+int handle_custom_string(
+			__attribute__((unused)) const format_specifier * spec,
+			va_list args, string_buffer *buffer)
+{
+	char *str, *dup_str;
+	int characters_added;
+	size_t initial_length;
+
+	str = va_arg(args, char *);
+	initial_length = buffer->length;
+
+	if (str)
+	{
+		dup_str = _strdup(str);
+		if (dup_str == NULL)
+			return (0); /* memory allocation failed, nothing is written */
+
+		/* Actual logic to handle the %S format specifier will be added soon */
+		append_string(buffer, dup_str);
+		safe_free(dup_str);
+	}
+	else
+	{
+		append_string(buffer, "(null)");
+	}
+
+	characters_added = buffer->length - initial_length;
+	return (characters_added);
+}

--- a/string_buffer.c
+++ b/string_buffer.c
@@ -1,0 +1,53 @@
+#include "main.h"
+
+/**
+ * init_string_buffer - initializes the string buffer used to store the output
+ * @buffer: where to store the result. (Dynamically handled)
+ */
+void init_string_buffer(string_buffer *buffer)
+{
+	buffer->data = NULL;
+	buffer->capacity = 0;
+	buffer->length = 0;
+}
+
+/**
+ * append_char - appends a character to the string buffer while allocating
+ * memory dynamically
+ * @buffer: the string buffer to save the result
+ * @c: the character to write
+ */
+void append_char(string_buffer *buffer, char c)
+{
+	size_t old_capacity = buffer->capacity;
+	char *new_data;
+
+	/* handle memory allocation */
+	if (buffer->length + 1 >= buffer->capacity)
+	{
+		buffer->capacity = (old_capacity == 0) ? 2 : old_capacity * 2;
+		new_data = _realloc(buffer->data, old_capacity, buffer->capacity);
+
+		if (new_data == NULL)
+			return; /* memory allocation failed */
+
+		buffer->data = new_data;
+	}
+	buffer->data[buffer->length] = c;
+	buffer->length++;
+	buffer->data[buffer->length] = '\0';
+}
+
+/**
+ * append_string - appends a string to the string buffer
+ * @buffer: the string buffer to hold the result
+ * @str: the string to append
+ */
+void append_string(string_buffer *buffer, const char *str)
+{
+	while (*str)
+	{
+		append_char(buffer, *str);
+		str++;
+	}
+}


### PR DESCRIPTION
This version includes functions that handle the `%s`, `%r`, `%R`, and `%S` format specifiers. With the exception of `%S`, the correct logic is added to ensure the performance of the functionality. The code logic for `%S` will be added soon. For now, it works as if it's `%s`.
